### PR TITLE
Automatic deployment to dev

### DIFF
--- a/clusters_setup/deploy.py
+++ b/clusters_setup/deploy.py
@@ -66,8 +66,8 @@ def main(module_name):
     """
     :param module_name: The environment (ie. staging, etc).
     """
-
-    kubernetes.config.load_kube_config()
+    service_account_path = os.path.join(os.path.abspath(os.path.dirname(os.path.dirname(__file__))), ".gcloud-key")
+    kubernetes.config.load_kube_config(config_file=service_account_path)
 
     global api_instance
     global extensions_api_instance

--- a/clusters_setup/deploy.py
+++ b/clusters_setup/deploy.py
@@ -67,7 +67,7 @@ def main(module_name):
     """
     :param module_name: The environment (ie. staging, etc).
     """
-    kubernetes.config.load_kube_config(os.path(BASE_DIR, ".gcloud-key"))
+    kubernetes.config.load_kube_config(os.path.join(BASE_DIR, ".gcloud-key"))
 
     global api_instance
     global extensions_api_instance

--- a/clusters_setup/deploy.py
+++ b/clusters_setup/deploy.py
@@ -67,8 +67,7 @@ def main(module_name):
     """
     :param module_name: The environment (ie. staging, etc).
     """
-    service_account_path = os.path.join(os.path.abspath(os.path.dirname(os.path.dirname(__file__))), "dev_kube_config")
-    kubernetes.config.load_kube_config(config_file=service_account_path)
+    kubernetes.config.load_kube_config()
 
     global api_instance
     global extensions_api_instance

--- a/clusters_setup/deploy.py
+++ b/clusters_setup/deploy.py
@@ -66,7 +66,7 @@ def main(module_name):
     """
     :param module_name: The environment (ie. staging, etc).
     """
-    service_account_path = os.path.join(os.path.abspath(os.path.dirname(os.path.dirname(__file__))), ".gcloud-key")
+    service_account_path = os.path.join(os.path.abspath(os.path.dirname(os.path.dirname(__file__))), "dev_kube_config")
     kubernetes.config.load_kube_config(config_file=service_account_path)
 
     global api_instance

--- a/clusters_setup/deploy.py
+++ b/clusters_setup/deploy.py
@@ -23,12 +23,12 @@ def create_ingress_yaml(module_name):
     with open(path) as yaml_file:
         content = yaml.safe_load(yaml_file.read())
         content['metadata']['annotations']['kubernetes.io/ingress.global-static-ip-name'] = module_name + '-aimmo-ingress'
-        
+
     return content
 
 
 def create_creator_yaml():
-    path = os.path.join(CURR_DIR, 'dev_rc_game_creator.yaml')
+    path = os.path.join(CURR_DIR, 'rc_aimmo_game_creator.yaml')
     with open(path) as yaml_file:
         content = yaml.safe_load(yaml_file.read())
     return content

--- a/clusters_setup/deploy.py
+++ b/clusters_setup/deploy.py
@@ -1,8 +1,6 @@
-from google.cloud import container_v1
 import os
 import kubernetes
 import yaml
-import requests
 import sys
 
 # Root directory of the project.

--- a/clusters_setup/deploy.py
+++ b/clusters_setup/deploy.py
@@ -1,0 +1,86 @@
+from google.cloud import container_v1
+import os
+import kubernetes
+import yaml
+import requests
+import sys
+
+# Root directory of the project.
+BASE_DIR = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+CURR_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+def create_ingress_yaml(module_name):
+    """
+    Uses a template yaml file in the same directory to construct a python yaml
+    object. Replaces the ingress.global-static-ip-name annotation with the
+    correct module name (depending on which cluster this script is ran in).
+
+    :param module_name: The name of the environment we're in (ie. staging, dev
+    :return: python object containing yaml.
+    """
+    path = os.path.join(CURR_DIR, 'ingress.yaml')
+    print("printing current directory: ", path)
+
+    with open(path) as yaml_file:
+        content = yaml.safe_load(yaml_file.read()).replace('REPLACE',
+                                                           (module_name + '-aimmo-ingress'))
+    return content
+
+
+def create_creator_yaml():
+    path = os.path.join(CURR_DIR, 'dev_rc_game_creator.yaml')
+    with open(path) as yaml_file:
+        content = yaml.safe_load(yaml_file.read())
+    return content
+
+
+def restart_pods(game_creator, ingress_yaml):
+    for rc in api_instance.list_namespaced_replication_controller('default').items:
+        api_instance.delete_namespaced_replication_controller(
+            body=kubernetes.client.V1DeleteOptions(),
+            name=rc.metadata.name,
+            namespace='default')
+    for pod in api_instance.list_namespaced_pod('default').items:
+        api_instance.delete_namespaced_pod(
+            body=kubernetes.client.V1DeleteOptions(),
+            name=pod.metadata.name,
+            namespace='default')
+    for service in api_instance.list_namespaced_service('default').items:
+        api_instance.delete_namespaced_service(
+            name=service.metadata.name,
+            namespace='default')
+    for ingress in extensions_api_instance.list_namespaced_ingress('default').items:
+        extensions_api_instance.delete_namespaced_ingress(
+            name=ingress.metadata.name,
+            namespace='default',
+            body=kubernetes.client.V1DeleteOptions())
+
+    extensions_api_instance.create_namespaced_ingress("default", ingress_yaml)
+
+    api_instance.create_namespaced_replication_controller(
+        body=game_creator,
+        namespace='default',
+    )
+
+
+def main(module_name):
+    """
+    :param module_name: The environment (ie. staging, etc).
+    """
+
+    kubernetes.config.load_kube_config()
+
+    global api_instance
+    global extensions_api_instance
+    api_instance = kubernetes.client.CoreV1Api()
+    extensions_api_instance = kubernetes.client.ExtensionsV1beta1Api()
+
+    ingress = create_ingress_yaml(module_name=module_name)
+    game_creator_rc = create_creator_yaml()
+
+    restart_pods(game_creator_rc, ingress)
+
+
+if __name__ == '__main__':
+    main(module_name=sys.argv[1])

--- a/clusters_setup/deploy.py
+++ b/clusters_setup/deploy.py
@@ -21,8 +21,9 @@ def create_ingress_yaml(module_name):
     print("printing current directory: ", path)
 
     with open(path) as yaml_file:
-        content = yaml.safe_load(yaml_file.read()).replace('REPLACE',
-                                                           (module_name + '-aimmo-ingress'))
+        content = yaml.safe_load(yaml_file.read())
+        content['metadata']['annotations']['kubernetes.io/ingress.global-static-ip-name'] = module_name + '-aimmo-ingress'
+        
     return content
 
 

--- a/clusters_setup/deploy.py
+++ b/clusters_setup/deploy.py
@@ -67,7 +67,7 @@ def main(module_name):
     """
     :param module_name: The environment (ie. staging, etc).
     """
-    kubernetes.config.load_kube_config(os.path.join(BASE_DIR, ".gcloud-key"))
+    kubernetes.config.load_kube_config("/home/runner/.kube/config")
 
     global api_instance
     global extensions_api_instance

--- a/clusters_setup/deploy.py
+++ b/clusters_setup/deploy.py
@@ -67,7 +67,7 @@ def main(module_name):
     """
     :param module_name: The environment (ie. staging, etc).
     """
-    kubernetes.config.load_kube_config()
+    kubernetes.config.load_kube_config(os.path(BASE_DIR, ".gcloud-key"))
 
     global api_instance
     global extensions_api_instance

--- a/clusters_setup/ingress.yaml
+++ b/clusters_setup/ingress.yaml
@@ -1,0 +1,17 @@
+# This yaml needs to be deployed every time a new version of the game is released.
+# The contents of ingress_nginx are a one time set up. See more in the wiki.
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: aimmo-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.global-static-ip-name: REPLACE
+spec:
+  rules:
+    - host:
+      http:
+        paths:
+            - backend:
+                serviceName: default-http-backend
+                servicePort: 80

--- a/clusters_setup/ingress_nginx/configmap.yaml
+++ b/clusters_setup/ingress_nginx/configmap.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-configuration
+  namespace: ingress-nginx
+  labels:
+    app: ingress-nginx

--- a/clusters_setup/ingress_nginx/default-backend-deployment.yaml
+++ b/clusters_setup/ingress_nginx/default-backend-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: default-http-backend
+  labels:
+    app: default-http-backend
+  namespace: ingress-nginx
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: default-http-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.4
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi

--- a/clusters_setup/ingress_nginx/default-backend-service.yaml
+++ b/clusters_setup/ingress_nginx/default-backend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  namespace: ingress-nginx
+  labels:
+    app: default-http-backend
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: default-http-backend

--- a/clusters_setup/ingress_nginx/namespace.yaml
+++ b/clusters_setup/ingress_nginx/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx

--- a/clusters_setup/ingress_nginx/patch-service-without-rbac.yaml
+++ b/clusters_setup/ingress_nginx/patch-service-without-rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+  namespace: ingress-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app: ingress-nginx
+    spec:
+      containers:
+        - name: nginx-ingress-controller
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.10.2
+          args:
+            - /nginx-ingress-controller
+            - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+            - --configmap=$(POD_NAMESPACE)/nginx-configuration
+            - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
+            - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+            - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+            - --annotations-prefix=nginx.ingress.kubernetes.io
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+          - name: http
+            containerPort: 80
+          - name: https
+            containerPort: 443

--- a/clusters_setup/ingress_nginx/service.yaml
+++ b/clusters_setup/ingress_nginx/service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app: ingress-nginx
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  - name: https
+    port: 443
+    targetPort: https

--- a/clusters_setup/ingress_nginx/tcp-servicespconfigmap.yaml
+++ b/clusters_setup/ingress_nginx/tcp-servicespconfigmap.yaml
@@ -1,0 +1,5 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tcp-services
+  namespace: ingress-nginx

--- a/clusters_setup/ingress_nginx/udp-services-configmap.yaml
+++ b/clusters_setup/ingress_nginx/udp-services-configmap.yaml
@@ -1,0 +1,5 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: udp-services
+  namespace: ingress-nginx

--- a/clusters_setup/ingress_nginx/without-rbac.yaml
+++ b/clusters_setup/ingress_nginx/without-rbac.yaml
@@ -1,0 +1,72 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+  namespace: ingress-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app: ingress-nginx
+      annotations:
+        prometheus.io/port: '10254'
+        prometheus.io/scrape: 'true'
+    spec:
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range="1024 65535"
+        image: alpine:3.6
+        imagePullPolicy: IfNotPresent
+        name: sysctl
+        securityContext:
+          privileged: true
+      containers:
+        - name: nginx-ingress-controller
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.10.2
+          args:
+            - /nginx-ingress-controller
+            - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+            - --configmap=$(POD_NAMESPACE)/nginx-configuration
+            - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
+            - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+            - --annotations-prefix=nginx.ingress.kubernetes.io
+            - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+          - name: http
+            containerPort: 80
+          - name: https
+            containerPort: 443
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1

--- a/clusters_setup/rc_aimmo_game_creator.yaml
+++ b/clusters_setup/rc_aimmo_game_creator.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: aimmo-game-creator
+spec:
+  replicas: 1
+  # selector identifies the set of Pods that this
+  # replication controller is responsible for managing
+  selector:
+    app: aimmo-game-creator
+  # podTemplate defines the 'cookie cutter' used for creating
+  # new pods when necessary
+  template:
+    metadata:
+      labels:
+        # Important: these labels need to match the selector above
+        # The api server enforces this constraint.
+        app: aimmo-game-creator
+    spec:
+      containers:
+      - name: aimmo-game-creator
+        image: ocadotechnology/aimmo-game-creator:latest
+        ports:
+        - containerPort: 80
+        env:
+        - name: IMAGE_SUFFIX
+          value: latest
+        - name: GAME_API_URL
+          value: https://staging-dot-decent-digit-629.appspot.com/aimmo/api/games/
+        - name: WORKER_MANAGER
+          value: kubernetes

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,12 +22,11 @@ export CACHE_PREFIX="${MODULE_NAME}-${VERSION}-"
 export GOOGLE_APPLICATION_CREDENTIALS=/home/runner/codeforlife-deploy-appengine/.gcloud-key
 
 # Install the dependencies for the following deploy script.
-# Kubernetes is a TEMPORARY solution. The version fixes a missing scope bug which has been
-# fixed in January 2018. No stable kubernetes package has been released since.
+# Kubernetes is a TEMPORARY solution. See issue 68.
 pip install kubernetes==5.0.0b1
 pip install pyyaml
 
-# Authenticate the cluster locally by creating via updating kubeconfig.
+# Authenticate the cluster by updating kubeconfig.
 ${GCLOUD} config set project ${APP_ID}
 ${GCLOUD} container clusters get-credentials ${MODULE_NAME} --zone europe-west1-b
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,6 +28,7 @@ pip install pyyaml
 # Authenticate the cluster locally by creating via updating kubeconfig.
 ${GCLOUD} config set project ${APP_ID}
 ${GCLOUD} container clusters get-credentials ${MODULE_NAME} --zone europe-west1-b
+${GCLOUD} auth application-default login
 
 # Deploy the correct kubernetes cluster.
 python clusters_setup/deploy.py "${MODULE_NAME}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,7 +22,9 @@ export CACHE_PREFIX="${MODULE_NAME}-${VERSION}-"
 export GOOGLE_APPLICATION_CREDENTIALS=/home/runner/codeforlife-deploy-appengine/.gcloud-key
 
 # Install the dependencies for the following deploy script.
-pip install kubernetes==4.0.0
+# Kubernetes is a TEMPORARY solution. The version fixes a missing scope bug which has been
+# fixed in January 2018. No stable kubernetes package has been released since.
+pip install kubernetes==5.0.0b1
 pip install pyyaml
 
 # Authenticate the cluster locally by creating via updating kubeconfig.
@@ -32,8 +34,7 @@ ${GCLOUD} container clusters get-credentials ${MODULE_NAME} --zone europe-west1-
 # Deploy the correct kubernetes cluster.
 python clusters_setup/deploy.py "${MODULE_NAME}"
 
-echo "hello"
-cat /home/runner/.kube/config
+
 #./manage.py migrate --noinput
 
 envsubst <app.yaml.tmpl >app.yaml

--- a/deploy.sh
+++ b/deploy.sh
@@ -27,6 +27,9 @@ envsubst <app.yaml.tmpl >app.yaml
 ${GCLOUD} app --quiet deploy app.yaml --project ${APP_ID} --version ${VERSION} --no-promote
 ${GCLOUD} app --quiet deploy cron.yaml --project ${APP_ID} --version ${VERSION} --no-promote
 
+# Deploy the correct kubernetes cluster.
+python clusters_setup/deploy.py "${VERSION}"
+
 # Test the site
 ./test.sh ${MODULE_NAME} ${VERSION}
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,12 +20,6 @@ export DATABASE_POSTFIX="$3"
 export DATABASE_NAME="cfl_${DATABASE_POSTFIX}"
 export CACHE_PREFIX="${MODULE_NAME}-${VERSION}-"
 
-#./manage.py migrate --noinput
-
-envsubst <app.yaml.tmpl >app.yaml
-
-${GCLOUD} app --quiet deploy app.yaml --project ${APP_ID} --version ${VERSION} --no-promote
-${GCLOUD} app --quiet deploy cron.yaml --project ${APP_ID} --version ${VERSION} --no-promote
 
 # Install the dependencies for the following deploy script.
 pip install kubernetes==4.0.0
@@ -33,6 +27,14 @@ pip install pyyaml
 
 # Deploy the correct kubernetes cluster.
 python clusters_setup/deploy.py "${MODULE_NAME}"
+
+#./manage.py migrate --noinput
+
+envsubst <app.yaml.tmpl >app.yaml
+
+${GCLOUD} app --quiet deploy app.yaml --project ${APP_ID} --version ${VERSION} --no-promote
+${GCLOUD} app --quiet deploy cron.yaml --project ${APP_ID} --version ${VERSION} --no-promote
+
 
 # Test the site
 ./test.sh ${MODULE_NAME} ${VERSION}

--- a/deploy.sh
+++ b/deploy.sh
@@ -27,6 +27,10 @@ envsubst <app.yaml.tmpl >app.yaml
 ${GCLOUD} app --quiet deploy app.yaml --project ${APP_ID} --version ${VERSION} --no-promote
 ${GCLOUD} app --quiet deploy cron.yaml --project ${APP_ID} --version ${VERSION} --no-promote
 
+# Install the dependencies for the following deploy script.
+pip install kubernetes==4.0.0
+pip install pyyaml
+
 # Deploy the correct kubernetes cluster.
 python clusters_setup/deploy.py "${VERSION}"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,7 +19,7 @@ export VERSION="$2"
 export DATABASE_POSTFIX="$3"
 export DATABASE_NAME="cfl_${DATABASE_POSTFIX}"
 export CACHE_PREFIX="${MODULE_NAME}-${VERSION}-"
-
+export GOOGLE_APPLICATION_CREDENTIALS=/home/runner/codeforlife-deploy-appengine/.gcloud-key
 
 # Install the dependencies for the following deploy script.
 pip install kubernetes==4.0.0
@@ -28,7 +28,6 @@ pip install pyyaml
 # Authenticate the cluster locally by creating via updating kubeconfig.
 ${GCLOUD} config set project ${APP_ID}
 ${GCLOUD} container clusters get-credentials ${MODULE_NAME} --zone europe-west1-b
-${GCLOUD} auth application-default login
 
 # Deploy the correct kubernetes cluster.
 python clusters_setup/deploy.py "${MODULE_NAME}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,7 +32,7 @@ pip install kubernetes==4.0.0
 pip install pyyaml
 
 # Deploy the correct kubernetes cluster.
-python clusters_setup/deploy.py "${VERSION}"
+python clusters_setup/deploy.py "${MODULE_NAME}"
 
 # Test the site
 ./test.sh ${MODULE_NAME} ${VERSION}

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,6 +25,10 @@ export CACHE_PREFIX="${MODULE_NAME}-${VERSION}-"
 pip install kubernetes==4.0.0
 pip install pyyaml
 
+# Authenticate the cluster locally by creating via updating kubeconfig.
+${GCLOUD} config set project ${APP_ID}
+${GCLOUD} container clusters get-credentials ${MODULE_NAME} --zone europe-west1-b
+
 # Deploy the correct kubernetes cluster.
 python clusters_setup/deploy.py "${MODULE_NAME}"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -27,14 +27,9 @@ envsubst <app.yaml.tmpl >app.yaml
 ${GCLOUD} app --quiet deploy app.yaml --project ${APP_ID} --version ${VERSION} --no-promote
 ${GCLOUD} app --quiet deploy cron.yaml --project ${APP_ID} --version ${VERSION} --no-promote
 
-<<<<<<< HEAD
 # Install the dependencies for the following deploy script.
 pip install kubernetes==4.0.0
 pip install pyyaml
-=======
-# Install the dependency for the following deploy script.
-pip install google-cloud==0.32.0
->>>>>>> 009b471f31a5453e5e03f06230ae0eda16b838c8
 
 # Deploy the correct kubernetes cluster.
 python clusters_setup/deploy.py "${VERSION}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,6 +32,8 @@ ${GCLOUD} container clusters get-credentials ${MODULE_NAME} --zone europe-west1-
 # Deploy the correct kubernetes cluster.
 python clusters_setup/deploy.py "${MODULE_NAME}"
 
+echo "hello"
+cat /home/runner/.kube/config
 #./manage.py migrate --noinput
 
 envsubst <app.yaml.tmpl >app.yaml


### PR DESCRIPTION
# Good to go! 🆗 

This PR will not add the functionality just yet, but it's needed in order to debug further unfortunately. [Complementary PR in the aimmo repository](https://github.com/ocadotechnology/aimmo/pull/455) will make sure we can still deploy by hand until this is fully implemented.

So far:
-  `deploy.sh` passes the version down to our new script now.
- new `deploy.py` will create the relevant ingress yaml, rc and restart pods.
- the `ingress.yaml` will hopefully have a field replaced with the correct name of the static ip.
- adding yaml files for setting up ingress_nginx correctly. This should only be done once and I have already done it, but just in case we need to reset anything, we have the correct versions saved in our version control. 
- **Kubernetes is now moved to version `5.0.0b1` which is an unstable version. Unfortunately the last stable version still has a unspecified scope bug and is unusable so we need to use this until we can upgrade to a stable released one.**

All docs will be updated in the `ocadotechnology/aimmo` repository. You can see the screenshots for that and suggest changes in that repo's PR too.