### PR TITLE
Google Cloud Engine Game Creator RC changed env name

### DIFF
--- a/clusters_setup/rc_aimmo_game_creator.yaml
+++ b/clusters_setup/rc_aimmo_game_creator.yaml
@@ -27,5 +27,5 @@ spec:
           value: latest
         - name: GAME_API_URL
           value: REPLACE_ME
-        - name: WORKER_MANAGER
+        - name: GAME_MANAGER
           value: kubernetes


### PR DESCRIPTION
As a result of https://github.com/ocadotechnology/aimmo/pull/573 things broke. We need to reflect on those changes in the app engine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/101)
<!-- Reviewable:end -->
