### PR TITLE
TEMPLATE_DEBUG deprecated

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -25,8 +25,6 @@ NOCAPTCHA = True
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-TEMPLATE_DEBUG = False
-
 # Application definition
 
 INSTALLED_APPS = (
@@ -195,7 +193,7 @@ TEMPLATES = [
         ],
         'APP_DIRS': True,
         'OPTIONS': {
-            'debug' : TEMPLATE_DEBUG,
+            'debug' : DEBUG,
             'context_processors': [
                 # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
                 # list if you haven't customized them:


### PR DESCRIPTION
(1_8.W001) The standalone TEMPLATE_* settings were deprecated in Django 1.8 and the TEMPLATES dictionary takes precedence. You must put the values of the following settings into your default TEMPLATES dict: TEMPLATE_DEBUG.
- Removed use of TEMPLATE_DEBUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/110)
<!-- Reviewable:end -->
