### PR TITLE
Point to semver implementation instead of versioneer

### DIFF
--- a/django_site/views.py
+++ b/django_site/views.py
@@ -1,13 +1,14 @@
 from django.http import JsonResponse
 
-import game._version
 import aimmo._version
-import portal._version
+import game
+import portal
+
 
 def versions(_request):
-    '''Return json containing the installed versions of the main packages.'''
+    """Return json containing the installed versions of the main packages."""
     return JsonResponse({
         'aimmo': aimmo._version.get_versions()['full-revisionid'],
-        'codeforlife-portal': portal._version.get_versions()['full-revisionid'],
-        'rapid-router': game._version.get_versions()['full-revisionid'],
+        'codeforlife-portal': portal.__version__,
+        'rapid-router': game.__version__
     })


### PR DESCRIPTION
For both game and portal projects, the appengine used to get the version from versioneer. Since versioneer has been deleted and automatic semver has been implemented in these projects, it needs to point to the __version__ to be able to deploy properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/154)
<!-- Reviewable:end -->
