### PR TITLE
Remove google.appengine.ext.appstats.recording.AppStatsDjangoMiddleware

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -144,9 +144,6 @@ if os.getenv("SERVER_SOFTWARE", "").startswith("Google App Engine"):
     EMAIL_BACKEND = "deploy.mail.EmailBackend"
     # Specify a queue name for the async. email backend.
     EMAIL_QUEUE_NAME = "default"
-    MIDDLEWARE.insert(
-        0, "google.appengine.ext.appstats.recording.AppStatsDjangoMiddleware"
-    )
 
     SOCIAL_AUTH_PANDASSO_KEY = "code-for-life"
     SOCIAL_AUTH_PANDASSO_SECRET = os.getenv("PANDASSO_SECRET")


### PR DESCRIPTION
This middleware no longer works with the updated version of Django we use and I couldn't find an updated version of it or any recent documentation referencing it. Looking into what the middleware does, it looks like it sends stats for RPC calls. As far as I'm aware, we don't use any RPC calls so this should be safe to remove

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/157)
<!-- Reviewable:end -->
