### PR TITLE
fix: changed path to portal online status middleware

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -59,7 +59,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "portal.middleware.online_status.middleware.OnlineStatusMiddleware",
+    "portal.middleware.online_status.OnlineStatusMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "deploy.middleware.exceptionlogging.ExceptionLoggingMiddleware",


### PR DESCRIPTION
Changed the path to the django online status middleware in settings, in accordances to the changes made on portal to fix the cache overflow issue on production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/160)
<!-- Reviewable:end -->
