### PR TITLE
fix: renamed aimmo to kurono in the django site urls file

### DIFF
--- a/django_site/urls.py
+++ b/django_site/urls.py
@@ -16,6 +16,6 @@ urlpatterns = [
     url(r"^administration/", include(admin.site.urls)),
     url(r"^rapidrouter/", include(game_urls)),
     url(r"^reports/", include(reports_urls)),
-    url(r"^aimmo/", include(aimmo_urls)),
+    url(r"^kurono/", include(aimmo_urls)),
     url(r"^versions/$", versions, name="versions"),
 ]


### PR DESCRIPTION
Renamed the url from "aimmo" to "kurono" in urls.py in the django site folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/180)
<!-- Reviewable:end -->
