### PR TITLE
Remove CSRF cookie setting

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -151,7 +151,6 @@ if os.getenv("SERVER_SOFTWARE", "").startswith("Google App Engine"):
     PANDASSO_URL = os.getenv("PANDASSO_URL")
 
     SESSION_COOKIE_SECURE = True
-    CSRF_COOKIE_SECURE = True
 
 else:
     DATABASES = {


### PR DESCRIPTION
## Description
This PR removes the CSRF_COOKIE_SECURE setting from the project.

## Motivation and Context
We believe that adding this setting [here](https://github.com/ocadotechnology/codeforlife-deploy-appengine/commit/6d8f01f3e89303f41c42df43cba4ed6076f6a2af) may be causing this [issue](https://github.com/ocadotechnology/aimmo/issues/1201).
We are removing it to see whether this fixes this issue.

## How Has This Been Tested?
This will be tested once the change is merged. The change will be deemed successful if the issue no longer occurs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/190)
<!-- Reviewable:end -->
