### PR TITLE
Remove online status middleware path

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -59,7 +59,6 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "portal.middleware.online_status.OnlineStatusMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "deploy.middleware.exceptionlogging.ExceptionLoggingMiddleware",


### PR DESCRIPTION
## Description
This PR removes the path to portal's online status middleware in the settings.

## Motivation and Context
This is done as part of the removal of the online status feature.
All the details on this can be found in the issue linked below.

## How Has This Been Tested?
This has been tested on portal when submitting the PR.
This change here will be tested when releasing on semaphore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/191)
<!-- Reviewable:end -->
