### PR TITLE
Revert remove CSRF cookie setting

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -150,6 +150,7 @@ if os.getenv("SERVER_SOFTWARE", "").startswith("Google App Engine"):
     PANDASSO_URL = os.getenv("PANDASSO_URL")
 
     SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
 
 else:
     DATABASES = {


### PR DESCRIPTION
## Description
This PR re-sets the CSRF cookie secure setting to True.

## Motivation and Context
This setting was removed in #190 to see whether it was causing the project to break (see issue details in #190).
It turns out that wasn't the case so this PR reverts that.

We also want to see whether this will interfere with the fact that the CSRF token is now sent to React via a cookie.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/192)
<!-- Reviewable:end -->
