### PR TITLE
feat: added django security middleware and set sts age

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -23,6 +23,8 @@ RECAPTCHA_PRIVATE_KEY = os.getenv("RECAPTCHA_PRIVATE_KEY", "NOT A SECRET")
 RECAPTCHA_PUBLIC_KEY = os.getenv("RECAPTCHA_PUBLIC_KEY", "NOT A SECRET")
 NOCAPTCHA = True
 
+SECURE_HSTS_SECONDS = 31536000  # One year
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
@@ -58,6 +60,7 @@ MIDDLEWARE = [
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
+    "django.middleware.security.SecurityMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",

--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -23,7 +23,7 @@ RECAPTCHA_PRIVATE_KEY = os.getenv("RECAPTCHA_PRIVATE_KEY", "NOT A SECRET")
 RECAPTCHA_PUBLIC_KEY = os.getenv("RECAPTCHA_PUBLIC_KEY", "NOT A SECRET")
 NOCAPTCHA = True
 
-SECURE_HSTS_SECONDS = 31536000  # One year
+SECURE_HSTS_SECONDS = 3600  # One hour, set to one year (31536000) after tested
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False


### PR DESCRIPTION
## Description
Added Django SecurityMiddleware and set Strict Transport Security age to 3600s (one hour).

## Motivation and Context
This is part of the missing HTTP headers issue raised before. The age was set as a small value to ensure all assets are served securely, before increasing it to the recommended value of 31536000s (one year).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/195)
<!-- Reviewable:end -->
