### PR TITLE
feat: increased STS header age to one year 

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -23,7 +23,7 @@ RECAPTCHA_PRIVATE_KEY = os.getenv("RECAPTCHA_PRIVATE_KEY", "NOT A SECRET")
 RECAPTCHA_PUBLIC_KEY = os.getenv("RECAPTCHA_PUBLIC_KEY", "NOT A SECRET")
 NOCAPTCHA = True
 
-SECURE_HSTS_SECONDS = 3600  # One hour, set to one year (31536000) after tested
+SECURE_HSTS_SECONDS = 31536000  # One year
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False


### PR DESCRIPTION
## Description
Increased the HTTP Strict Transport Security header max age value to one year, as recommended, after having implemented it with the value of one hour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/197)
<!-- Reviewable:end -->
