### PR TITLE
Remove reversion from Django settings

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -51,7 +51,6 @@ INSTALLED_APPS = (
     "rest_framework",
     "treebeard",
     "sekizai",  # for javascript and css management
-    "reversion",
     "aimmo",
 )
 


### PR DESCRIPTION
## Description
This PR removes the reversion package from Django's settings.

## Motivation and Context
As part of the Python 3 upgrade we have decided to remove django-reversion from the portal project. This means we also have to remove it from the settings here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/198)
<!-- Reviewable:end -->
