### PR TITLE
Use requests_toolbelt monkeypatch for GAE adapter

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -10,7 +10,7 @@ from google.appengine.ext import vendor
 # sure that they are importable by the application.
 vendor.add('lib')
 
-from requests_toolbelt.adapters import appengine
-
-# Monkey patch from requests_toolbelt to enable GAE to work with requests.
-appengine.monkeypatch()
+# from requests_toolbelt.adapters import appengine
+#
+# # Monkey patch from requests_toolbelt to enable GAE to work with requests.
+# appengine.monkeypatch()

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -9,3 +9,8 @@ from google.appengine.ext import vendor
 # Third-party libraries are stored in "lib", vendoring will make
 # sure that they are importable by the application.
 vendor.add('lib')
+
+from requests_toolbelt.adapters import appengine
+
+# Monkey patch from requests_toolbelt to enable GAE to work with requests.
+appengine.monkeypatch()

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -10,7 +10,7 @@ from google.appengine.ext import vendor
 # sure that they are importable by the application.
 vendor.add('lib')
 
-# from requests_toolbelt.adapters import appengine
-#
-# # Monkey patch from requests_toolbelt to enable GAE to work with requests.
-# appengine.monkeypatch()
+from requests_toolbelt.adapters import appengine
+
+# Monkey patch from requests_toolbelt to enable GAE to work with requests.
+appengine.monkeypatch()

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ gem install sass --version 3.3.4
 rbenv rehash
 pip install beautifulsoup4
 pip install requests
-pip install requests_toolbet
+pip install requests-toolbelt
 
 pip install -t lib codeforlife-portal
 if [ "$ENVIRONMENT" = "default" ]

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,6 @@ gem install sass --version 3.3.4
 rbenv rehash
 pip install beautifulsoup4
 pip install requests
-pip install requests-toolbelt
 
 pip install -t lib codeforlife-portal
 if [ "$ENVIRONMENT" = "default" ]
@@ -15,8 +14,6 @@ then
 else
     pip install -t lib --pre --upgrade --no-deps aimmo
 fi
-
-pip install urllib3==1.23
 
 python install_gaerpytz.py
 

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@ gem install sass --version 3.3.4
 rbenv rehash
 pip install beautifulsoup4
 pip install requests
+pip install requests_toolbet
 
 pip install -t lib codeforlife-portal
 if [ "$ENVIRONMENT" = "default" ]

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@ export ENVIRONMENT="$1"
 gem install sass --version 3.3.4
 rbenv rehash
 pip install beautifulsoup4
-pip install -t lib requests-toolbelt
 pip install requests
+pip install -t lib requests-toolbelt
 
 pip install -t lib codeforlife-portal
 if [ "$ENVIRONMENT" = "default" ]

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,8 @@ else
     pip install -t lib --pre --upgrade --no-deps aimmo
 fi
 
+pip install urllib3==1.23
+
 python install_gaerpytz.py
 
 ./manage.py collectstatic --noinput

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ export ENVIRONMENT="$1"
 gem install sass --version 3.3.4
 rbenv rehash
 pip install beautifulsoup4
+pip install -t lib requests-toolbelt
 pip install requests
 
 pip install -t lib codeforlife-portal

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,6 +25,7 @@ export GOOGLE_APPLICATION_CREDENTIALS=/home/runner/codeforlife-deploy-appengine/
 # Kubernetes is a TEMPORARY solution. See issue 68.
 pip install kubernetes==5.0.0
 pip install pyyaml
+pip install requests-toolbelt
 
 # Authenticate the cluster by updating kubeconfig.
 ${GCLOUD} config set project ${APP_ID}

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,6 @@ export GOOGLE_APPLICATION_CREDENTIALS=/home/runner/codeforlife-deploy-appengine/
 # Kubernetes is a TEMPORARY solution. See issue 68.
 pip install kubernetes==5.0.0
 pip install pyyaml
-pip install requests-toolbelt
 
 # Authenticate the cluster by updating kubeconfig.
 ${GCLOUD} config set project ${APP_ID}


### PR DESCRIPTION
## Description
This PR makes use of requests_toolbelt's GAE adapter monkeypatch in the appengine_config.py file.

## Motivation and Context
The reason for this is to fix a bug that was introduced after we upgraded urllib3 to 1.24 in portal. The bug was causing registration to fail when users would tick the box to be added to our salesforce mailing list.

## How Has This Been Tested?
Manually by deploying to staging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/199)
<!-- Reviewable:end -->
