### PR TITLE
fix: don’t use the version name in the cache

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -18,7 +18,7 @@ export MODULE_NAME=$1
 export VERSION="$2"
 export DATABASE_POSTFIX="$3"
 export DATABASE_NAME="cfl_${DATABASE_POSTFIX}"
-export CACHE_PREFIX="${MODULE_NAME}-${VERSION}-"
+export CACHE_PREFIX="${MODULE_NAME}-"
 export GOOGLE_APPLICATION_CREDENTIALS=/home/runner/codeforlife-deploy-appengine/.gcloud-key
 
 # Install the dependencies for the following deploy script.


### PR DESCRIPTION
BREAKING CHANGE: cache prefix has changed format

This should fix user sessions disappearing on deployment

Signed-off-by: Niket <niket@canpoi.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/200)
<!-- Reviewable:end -->
