### PR TITLE
fix: remove django forms bootstrap

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -47,7 +47,6 @@ INSTALLED_APPS = (
     "django.contrib.staticfiles",
     "django.contrib.sites",
     "django_countries",
-    "django_forms_bootstrap",
     "rest_framework",
     "treebeard",
     "sekizai",  # for javascript and css management


### PR DESCRIPTION
unused dependency

Signed-off-by: Niket Shah <masterniket@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/204)
<!-- Reviewable:end -->
