### PR TITLE
fix: Remove _sass.so file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ else
     pip install -t lib --pre --upgrade --no-deps aimmo
 fi
 
-pip uninstall libsass
+rm ./lib/_sass.so
 
 python install_gaerpytz.py
 

--- a/build.sh
+++ b/build.sh
@@ -7,13 +7,13 @@ pip install beautifulsoup4
 pip install requests
 pip install -t lib requests-toolbelt
 
-pip install -t lib codeforlife-portal
-#if [ "$ENVIRONMENT" = "default" ]
-#then
-#    pip install -t lib --upgrade --no-deps aimmo
-#else
-#    pip install -t lib --pre --upgrade --no-deps aimmo
-#fi
+#pip install -t lib codeforlife-portal
+if [ "$ENVIRONMENT" = "default" ]
+then
+    pip install -t lib --upgrade --no-deps aimmo
+else
+    pip install -t lib --pre --upgrade --no-deps aimmo
+fi
 
 python install_gaerpytz.py
 

--- a/build.sh
+++ b/build.sh
@@ -7,13 +7,15 @@ pip install beautifulsoup4
 pip install requests
 pip install -t lib requests-toolbelt
 
-#pip install -t lib codeforlife-portal
+pip install -t lib codeforlife-portal
 if [ "$ENVIRONMENT" = "default" ]
 then
     pip install -t lib --upgrade --no-deps aimmo
 else
     pip install -t lib --pre --upgrade --no-deps aimmo
 fi
+
+pip uninstall libsass
 
 python install_gaerpytz.py
 

--- a/build.sh
+++ b/build.sh
@@ -9,12 +9,13 @@ pip install requests
 pip install -t lib requests-toolbelt
 
 pip install -t lib codeforlife-portal
-if [ "$ENVIRONMENT" = "default" ]
-then
-    pip install -t lib --upgrade --no-deps aimmo
-else
-    pip install -t lib --pre --upgrade --no-deps aimmo
-fi
+pip install -t lib git+https://github.com/ocadotechnology/aimmo.git@change_bundling_order
+#if [ "$ENVIRONMENT" = "default" ]
+#then
+#    pip install -t lib --upgrade --no-deps aimmo
+#else
+#    pip install -t lib --pre --upgrade --no-deps aimmo
+#fi
 
 python install_gaerpytz.py
 

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,6 @@ pip install requests
 pip install -t lib requests-toolbelt
 
 pip install -t lib codeforlife-portal
-pip install -t lib git+https://github.com/ocadotechnology/aimmo.git@change_bundling_order
 #if [ "$ENVIRONMENT" = "default" ]
 #then
 #    pip install -t lib --upgrade --no-deps aimmo

--- a/build.sh
+++ b/build.sh
@@ -15,8 +15,8 @@ else
     pip install -t lib --pre --upgrade --no-deps aimmo
 fi
 
-rm ./lib/_sass.so
-
 python install_gaerpytz.py
 
 ./manage.py collectstatic --noinput
+
+rm ./lib/_sass.so

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,6 @@
 
 export ENVIRONMENT="$1"
 
-gem install sass --version 3.3.4
 rbenv rehash
 pip install beautifulsoup4
 pip install requests


### PR DESCRIPTION
## Description
This PR removes the `_sass.so` file from the `lib` folder.

## Motivation and Context
The `_sass.so` file is greater than 30MB in size and was uploaded to the GCP storage which caused the deployment to fail. This PR removes after the static files are collected.

## How Has This Been Tested?
Manually tested on dev.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/205)
<!-- Reviewable:end -->
