### PR TITLE
fix: Remove django-casper

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -31,7 +31,6 @@ DEBUG = False
 # Application definition
 
 INSTALLED_APPS = (
-    "casper",
     "deploy",
     "portal",
     "captcha",


### PR DESCRIPTION
## Description
This PR removes django-casper from the installed apps.

## Motivation and Context
Django casper isn't used and is incompatible with Python 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/207)
<!-- Reviewable:end -->
