### PR TITLE
fix: Install deploy after captcha

### DIFF
--- a/django_site/settings.py
+++ b/django_site/settings.py
@@ -32,9 +32,9 @@ DEBUG = False
 
 INSTALLED_APPS = (
     "casper",
-    "deploy",
     "portal",
     "captcha",
+    "deploy",
     "reports",
     "game",
     #'djangocms_admin_style',  # for the admin skin. You **must** add 'djangocms_admin_style' in the list **before** 'django.contrib.admin'.


### PR DESCRIPTION
## Description
This PR installs deploy after captcha in installed apps.

## Motivation and Context
It seems like moving captcha after deploy has caused tests on rapid router that need to disable the captcha to fail again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/208)
<!-- Reviewable:end -->
