### PR TITLE
Add GCloud GKE auth package

### DIFF
--- a/.github/actions/deploy_gcloud/action.yml
+++ b/.github/actions/deploy_gcloud/action.yml
@@ -169,8 +169,7 @@ runs:
       shell: bash
 
     - name: "Get cluster credentials"
-      run: |
-        sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+      run: |-
         gcloud container clusters get-credentials "aimmo-$MODULE_NAME" --zone "$GKE_ZONE"
       env:
         MODULE_NAME: ${{ inputs.module-name }}

--- a/.github/actions/deploy_gcloud/action.yml
+++ b/.github/actions/deploy_gcloud/action.yml
@@ -169,7 +169,8 @@ runs:
       shell: bash
 
     - name: "Get cluster credentials"
-      run: |-
+      run: |
+        sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
         gcloud container clusters get-credentials "aimmo-$MODULE_NAME" --zone "$GKE_ZONE"
       env:
         MODULE_NAME: ${{ inputs.module-name }}

--- a/.github/workflows/deploy_default.yml
+++ b/.github/workflows/deploy_default.yml
@@ -33,9 +33,9 @@ jobs:
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: "337.0.0"
-          project_id: ${{ env.APP_ID }}
+
+      - name: GKE auth
+        uses: simenandre/setup-gke-gcloud-auth-plugin@v1
 
       - name: Deploy to Google Cloud
         uses: ./.github/actions/deploy_gcloud

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -39,11 +39,11 @@ jobs:
           python-version: "3.8.x"
           architecture: "x64"
 
-      - id: gcauth
-        name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCLOUD_AUTH }}
+#      - id: gcauth
+#        name: Authenticate to Google Cloud
+#        uses: google-github-actions/auth@v2
+#        with:
+#          credentials_json: ${{ secrets.GCLOUD_AUTH }}
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -41,15 +41,12 @@ jobs:
 
       - id: gcauth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCLOUD_AUTH }}
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: "337.0.0"
-          project_id: ${{ env.APP_ID }}
 
       - name: Deploy to Google Cloud
         uses: ./.github/actions/deploy_gcloud

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -51,11 +51,6 @@ jobs:
       - name: GKE auth
         uses: simenandre/setup-gke-gcloud-auth-plugin@v1
 
-#      - uses: google-github-actions/get-gke-credentials@v2
-#        with:
-#          cluster_name: aimmo-dev
-#          location: europe-west1-b
-
       - name: Deploy to Google Cloud
         uses: ./.github/actions/deploy_gcloud
         with:

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -39,11 +39,11 @@ jobs:
           python-version: "3.8.x"
           architecture: "x64"
 
-#      - id: gcauth
-#        name: Authenticate to Google Cloud
-#        uses: google-github-actions/auth@v2
-#        with:
-#          credentials_json: ${{ secrets.GCLOUD_AUTH }}
+      - id: gcauth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCLOUD_AUTH }}
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -51,10 +51,10 @@ jobs:
       - name: GKE auth
         uses: simenandre/setup-gke-gcloud-auth-plugin@v1
 
-      - uses: google-github-actions/get-gke-credentials@v2
-        with:
-          cluster_name: aimmo-dev
-          location: europe-west1-b
+#      - uses: google-github-actions/get-gke-credentials@v2
+#        with:
+#          cluster_name: aimmo-dev
+#          location: europe-west1-b
 
       - name: Deploy to Google Cloud
         uses: ./.github/actions/deploy_gcloud

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: GKE auth
+        uses: simenandre/setup-gke-gcloud-auth-plugin@v1
+
+      - uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: aimmo-dev
+          location: europe-west1-b
+
       - name: Deploy to Google Cloud
         uses: ./.github/actions/deploy_gcloud
         with:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -33,9 +33,9 @@ jobs:
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: "337.0.0"
-          project_id: ${{ env.APP_ID }}
+
+      - name: GKE auth
+        uses: simenandre/setup-gke-gcloud-auth-plugin@v1
 
       - name: Deploy to Google Cloud
         uses: ./.github/actions/deploy_gcloud


### PR DESCRIPTION
Adds a step to add the newly required gke gcloud auth package, since we upgraded the setup-gcloud action recently.

New action used to install package: https://github.com/marketplace/actions/setup-gke-gcloud-auth-plugin.

Note that the step to get GKE credentials in the action's docs is [already performed](https://github.com/ocadotechnology/codeforlife-deploy-appengine/blob/master/.github/actions/deploy_gcloud/action.yml#L171).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-deploy-appengine/314)
<!-- Reviewable:end -->
